### PR TITLE
Include missing function declarations

### DIFF
--- a/main.c
+++ b/main.c
@@ -1,3 +1,4 @@
+#define _DEFAULT_SOURCE
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -6,6 +7,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <math.h>
+#include <stdlib.h>
 
 #define MAX_BUF 1024
 


### PR DESCRIPTION
Let's include the headers with declaration of what is used. The setenv
manpage has the details on _DEFAULT_SOURCE (or _BSD_SOURCE) for glibc.